### PR TITLE
Optional update dictionaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,4 @@ com_crashlytics_export_strings.xml
 crashlytics.properties
 crashlytics-build.properties
 fabric.properties
+.vscode


### PR DESCRIPTION
General problem:

the RAFCON default config pollutes the config of the RAFCON setup used for skill development. We need to remove the default library-root-keys.

There should be optional flag that allows to merge (update) the dictionaries in the default configuration or just replace them.